### PR TITLE
Make the boostrapper more efficient

### DIFF
--- a/Bootstrapper/appleGuiceBootstrapper.cpp
+++ b/Bootstrapper/appleGuiceBootstrapper.cpp
@@ -198,20 +198,6 @@ void parseLine(string &headerEntry,
 	}
 }
 
-set<string> filterSuperProtocols(set<string> superProtocols) {
-    set<string> filteredSuperProtocols;
-    
-    for(set<string>::const_iterator protocolNameIterator = superProtocols.begin(); protocolNameIterator != superProtocols.end(); protocolNameIterator++ ) {
-        string protocolName = *protocolNameIterator;
-        
-        if (!isNSObject(protocolName)) {
-            filteredSuperProtocols.insert(protocolName);
-        }
-        
-    }
-    return filteredSuperProtocols;
-}
-
 void addBindToResultList(string &className,
                          set<string> implementedProtocols,
                          unordered_map<string, set<string> > &protocolToSuperProtocols,

--- a/Bootstrapper/appleGuiceBootstrapper.sh
+++ b/Bootstrapper/appleGuiceBootstrapper.sh
@@ -29,7 +29,7 @@ then
     make EXENAME=${bootstrapper} CXXFLAGS=-mios-version-min=7.0.0
 fi
 
-interfaceDeclerations=$(grep -sirhE --include=*.h --regexp='((@interface[^:]+:\s*[^>{}*/!]*>?)|(@protocol[^<]*<[^>]+>))' ${path});
+interfaceDeclerations=$(grep -sirhE --include=*.h --exclude=$3 --exclude-dir=$4 --regexp='((@interface[^:]+:\s*[^>{}*/!]*>?)|(@protocol[^<]*<[^>]+>))' ${path});
 
 result=$(echo "${interfaceDeclerations}" | ${scriptDir}/${bootstrapper});
 

--- a/Bootstrapper/appleGuiceBootstrapper.sh
+++ b/Bootstrapper/appleGuiceBootstrapper.sh
@@ -22,6 +22,7 @@ bootstrapper="bootStrapper";
 
 path=$1;
 scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+excludePrefixes=$5
 
 if [ ! -f ${scriptDir}/${bootstrapper} ]
 then
@@ -31,7 +32,7 @@ fi
 
 interfaceDeclerations=$(grep -sirhE --include=*.h --exclude=$3 --exclude-dir=$4 --regexp='((@interface[^:]+:\s*[^>{}*/!]*>?)|(@protocol[^<]*<[^>]+>))' ${path});
 
-result=$(echo "${interfaceDeclerations}" | ${scriptDir}/${bootstrapper});
+result=$(echo "${interfaceDeclerations}" | ${scriptDir}/${bootstrapper} ${excludePrefixes});
 
 if [ "$2" ]; then
 	echo > $2;


### PR DESCRIPTION
The improvements -
1. The original code went over the same classes twice. Made sure each class is only deal with once.
2. Made sure we are not traversing over NSObject, <NSObject> protocol and classes that are prefixed with UI (Like UIView, UIViewController…)
3. Got rid of recursions and implemented everything iteratively. Recursion adds couple of more seconds to the execution time.
4. appleGuiceBootstrapper.sh has an option to exclude certain files (like .frameworks) or directories (like Pods)

Overral I saw 70-80% improvement in the execution time.